### PR TITLE
Remove user creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,35 @@ The generated users are members of the group "admin-org-root" and have the "forc
 ## Usage
 
 ```hcl
-    module "aws-iam-user-group" {
+    module "aws_iam_user_group" {
       source         = "trussworks/iam-user-group/aws"
+      version = "1.2.0"
 
       user_names = ["user1", "user2"]
       group_name = "group-name"
       allowed_roles = []
       }
+```
+
+## Usage example
+```hcl
+locals {
+  user_list = ["user1", "user2"]
+  force_destroy = true
+}
+
+resource "aws_iam_user" "user" {
+  for_each = toset(var.user_list)
+  name     = each.value
+}
+
+module "aws_iam_user_group" {
+  source         = "trussworks/iam-user-group/aws"
+  version = "1.2.0"
+  user_names = values(aws_iam_user.user)[*].name
+  group_name = "group-name"
+  allowed_roles = []
+}
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ The group has a policy that only allows the assumption of the IAM roles defined 
 
 The generated users are members of the group "admin-org-root" and have the "force_destroy" flag set to true.
 
-*NOTE*: So far you must use this in conjunction with the module "trussworks/mfa/aws" to enforce mfa of the group this module creates.
+_NOTE_: So far you must use this in conjunction with the module "trussworks/mfa/aws" to enforce mfa of the group this module creates.
 
-*Philosophical note*: these groups should map 1:1 to IAM roles defined in your Terraform files. These should be defined in a separate module that could be reused in different accounts across your AWS org. So you may have multiple allowed roles with the same name across your accounts as a variable.
+_Philosophical note_: these groups should map 1:1 to IAM roles defined in your Terraform files. These should be defined in a separate module that could be reused in different accounts across your AWS org. So you may have multiple allowed roles with the same name across your accounts as a variable.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The generated users are members of the group "admin-org-root" and have the "forc
 ```
 
 ## Usage example
+
 ```hcl
 locals {
   user_list = ["user1", "user2"]
@@ -49,9 +50,8 @@ module "aws_iam_user_group" {
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | allowed\_roles | The roles that this group is allowed to assume. | list(string) | n/a | yes |
-| force\_destroy\_users | Sets 'force_destroy' to true or false for all IAM users generated with this module. Note:Turning force_destroy off means that a user with IAM permissions will have to go and remove MFA and keys from a user you might be managing this way. | bool | `"true"` | no |
 | group\_name | The name of the group to be created. | string | n/a | yes |
-| user\_names | Create IAM users with these names. | list(string) | `[]` | no |
+| user\_list | List of IAM users to add to the group. | list(string) | `[]` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -5,13 +5,14 @@ The group has a policy that only allows the assumption of the IAM roles defined 
 
 The generated users are members of the group "admin-org-root" and have the "force_destroy" flag set to true.
 
-NOTE: So far you must use this in conjunction with the module "trussworks/mfa/aws" to enforce mfa of the group this module creates.
+*NOTE*: So far you must use this in conjunction with the module "trussworks/mfa/aws" to enforce mfa of the group this module creates.
+
+*Philosophical note*: these groups should map 1:1 to IAM roles defined in your Terraform files. These should be defined in a separate module that could be reused in different accounts across your AWS org. So you may have multiple allowed roles with the same name across your accounts as a variable.
 
 ## Usage
 
 ```hcl
     module "aws-iam-user-group" {
-      # to be finalized
       source         = "trussworks/iam-user-group/aws"
 
       user_names = ["user1", "user2"]

--- a/main.tf
+++ b/main.tf
@@ -1,15 +1,4 @@
 #
-# Generate IAM users
-#
-
-resource "aws_iam_user" "user" {
-  for_each = toset(var.user_names)
-  name     = each.value
-  # Set force_destroy = true to make user clean up easier later.
-  force_destroy = var.force_destroy_users
-}
-
-#
 # IAM group + membership of group
 #
 
@@ -20,7 +9,7 @@ resource "aws_iam_group" "user_group" {
 resource "aws_iam_group_membership" "user_group" {
   name = "${var.group_name}-membership"
 
-  users = values(aws_iam_user.user)[*].name
+  users = var.user_list
 
   group = aws_iam_group.user_group.name
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,5 @@
 variable "user_names" {
-  description = "Create IAM users with these names."
+  description = "List of IAM users to add to the group."
   type        = list(string)
   default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,13 +1,7 @@
-variable "user_names" {
+variable "user_list" {
   description = "List of IAM users to add to the group."
   type        = list(string)
   default     = []
-}
-
-variable "force_destroy_users" {
-  description = "Sets 'force_destroy' to true or false for all IAM users generated with this module. Note:Turning force_destroy off means that a user with IAM permissions will have to go and remove MFA and keys from a user you might be managing this way."
-  type        = bool
-  default     = true
 }
 
 variable "group_name" {


### PR DESCRIPTION
I caught that if you have multiple groups defined this way, you're going to have a harder time moving people between groups if roles change. I pulled out the user creation based on a list and put it as a usage example.