### PR TITLE
pins required provider version

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,13 @@ module "aws_iam_user_group" {
 | Name | Version |
 |------|---------|
 | terraform | ~> 0.12.0 |
+| aws | ~> 2.70 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | ~> 2.70 |
 
 ## Inputs
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,7 @@
 terraform {
   required_version = "~> 0.12.0"
+
+  required_providers {
+    aws = "~> 2.70"
+  }
 }


### PR DESCRIPTION
Pins aws provider to 2.70 before we move to 3.0